### PR TITLE
Split off the PHP library components from liquidweb/htaccess-validator

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# PHP PSR-12 Coding Standards
+# http://www.php-fig.org/psr/psr-12/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{php,json}]
+indent_style = space
+indent_size = 4
+
+[*.md]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+.* export-ignore
+phpunit.xml.dist export-ignore
+tests export-ignore

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,43 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+  pull_request:
+
+jobs:
+  phpunit:
+    name: PHPUnit
+    strategy:
+      matrix:
+        php: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-suggest --no-progress
+
+      - name: Run test suite
+        run: composer test:unit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,14 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: none
 
+      # Invoke Apache once as root to ensure that /var/run/apache2 gets created
+      - name: Set up the Apache process
+        if: runner.os == 'Linux'
+        run: sudo apachectl -t -C 'ServerName example.com' -D DUMP_VHOSTS
+
+      - name: Verify default Apache configuration
+        run: apachectl -t -C "ServerName example.com"
+
       - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 composer.lock
 tests/tmp
 vendor
+
+# System files
+.DS_Store
+Thumbs.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+Initial release of the package.
+
+
+[Unreleased]: https://github.com/liquidweb/htaccess-validator-php/compare/main...develop

--- a/README.md
+++ b/README.md
@@ -1,0 +1,64 @@
+# Htaccess Validator (Composer Package)
+
+This is a Composer package wrapper for [Liquid Web's Htaccess Validator script](https://github.com/liquidweb/htaccess-validator), enabling PHP applications to easily validate Htaccess files.
+
+
+## Installation
+
+The easiest way to install the package is via [Composer](https://getcomposer.org):
+
+```
+$ composer require liquidweb/htaccess-validator
+```
+
+As the package uses Apache2 itself to validate, it must be available within your environment. [The Liquid Web Knowledge Base has instructions for installing Apache on most popular platforms](https://www.liquidweb.com/kb/install-apache-2-ubuntu-18-04/).
+
+
+## Usage
+
+There are two main ways to use the validator:
+
+1. As a stand-alone tool via the command line
+2. As a PHP library (requires `proc_open` to be available)
+
+### Validating Apache2 configurations from the command line interface (CLI)
+
+The `bin/validate-htaccess` script accepts a configuration file for validation:
+
+```sh
+$ bin/validate-htaccess /path/to/some/file.conf
+```
+
+The script will return a non-zero exit code if validation errors were detected. [Individual codes are documented in the script's header](https://github.com/liquidweb/htaccess-validator/blob/develop/bin/validate-htaccess#L15).
+
+### Validating Apache2 configurations within a PHP script
+
+The `LiquidWeb\HtaccessValidator\Validator` class serves as a wrapper around the `bin/validate-htaccess` script, enabling applications to validate Apache2 configurations programmatically.
+
+There are two ways to instantiate the class:
+
+1. Passing the full system path of the file under validation to the class constructor:
+
+	```php
+    use LiquidWeb\HtaccessValidator\Validator;
+
+	$validator = new Validator($file);
+	```
+
+2. Passing the configuration directly to the `::createFromString()` factory method:
+
+    ```php
+    use LiquidWeb\HtaccessValidator\Validator;
+
+	$validator = Validator::createFromString('Options +FollowSymLinks');
+	```
+
+Once you have a Validator instance, you may validate it in two ways:
+
+```php
+# Throws a LiquidWeb\HtaccessValidator\Exceptions\ValidationException upon failure.
+$validator->validate();
+
+# Return a boolean.
+$validator->isValid();
+```

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
         "issues": "https://github.com/liquidweb/htaccess-validator-php/issues",
         "source": "https://github.com/liquidweb/htaccess-validator-php"
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "RC",
     "require": {
         "php": "^5.6||^7.0||^8.0",
-        "liquidweb/htaccess-validator-shell": "dev-develop"
+        "liquidweb/htaccess-validator-shell": "^0.1"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^5.2"

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,10 @@
             "homepage": "https://stevegrunwell.com"
         }
     ],
+    "support": {
+        "issues": "https://github.com/liquidweb/htaccess-validator-php/issues",
+        "source": "https://github.com/liquidweb/htaccess-validator-php"
+    },
     "minimum-stability": "stable",
     "require": {
         "php": "^5.6||^7.0||^8.0",

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,40 @@
+{
+    "name": "liquidweb/htaccess-validator",
+    "description": "Lint and validate Apache2 Htaccess files",
+    "type": "library",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Steve Grunwell",
+            "homepage": "https://stevegrunwell.com"
+        }
+    ],
+    "minimum-stability": "stable",
+    "require": {
+        "php": "^5.6||^7.0||^8.0",
+        "liquidweb/htaccess-validator-shell": "dev-develop"
+    },
+    "require-dev": {
+        "symfony/phpunit-bridge": "^5.2"
+    },
+    "autoload": {
+        "psr-4": {
+            "LiquidWeb\\HtaccessValidator\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "preferred-install": "dist",
+        "sort-packages": true
+    },
+    "scripts": {
+        "test:unit": "simple-phpunit --testdox --color=always"
+    },
+    "scripts-descriptions": {
+        "test:unit": "Run the PHPUnit test suite."
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<phpunit
+    bootstrap="vendor/autoload.php"
+    colors="true"
+>
+    <testsuites>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Integration">
+            <directory suffix="Test.php">./tests/Integration</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Exceptions/ValidationException.php
+++ b/src/Exceptions/ValidationException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace LiquidWeb\HtaccessValidator\Exceptions;
+
+class ValidationException extends \DomainException
+{
+
+}

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace LiquidWeb\HtaccessValidator;
+
+use LiquidWeb\HtaccessValidator\Exceptions\ValidationException;
+
+class Validator
+{
+	/**
+	 * @var string|Resource The file being validated.
+	 */
+	protected $file;
+
+	/**
+	 * Construct a new instance of the class.
+	 *
+	 * @param string|resource $file The file being validated. This may be an actual file or a
+     *                              stream resource.
+	 */
+	public function __construct($file)
+	{
+		$this->file = $file;
+	}
+
+	/**
+	 * Retrieve the underlying filepath.
+	 *
+	 * @return string The path to $this->file.
+	 */
+	public function getFilePath()
+	{
+		return is_resource($this->file)
+            ? stream_get_meta_data($this->file)['uri']
+            : (string) $this->file;
+	}
+
+	/**
+	 * Simply return whether or not the given file's syntax is valid.
+	 *
+	 * @return bool True if validation passes, false if an error is encountered.
+	 */
+	public function isValid()
+	{
+		try {
+			$this->validate();
+		} catch (ValidationException $e) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validate the given file.
+	 *
+	 * Validation is handled by the underlying Apache instance, using a stripped-down configuration
+	 * so the entire Apache configuration consists of a) the necessary bootstrapping and b) the
+	 * contents of $this->file.
+	 *
+	 * @throws ValidationException
+	 */
+	public function validate()
+	{
+        try {
+            $result = $this->runValidator();
+        } catch (\Exception $e) {
+            throw new ValidationException(
+                sprintf('There was an error running the validate-htaccess script: %s', $e->getMessage()),
+                $e->getCode(),
+                $e
+            );
+        }
+
+		if (0 !== $result->exitCode) {
+            throw new ValidationException(
+                sprintf('Validation errors were encountered: %s', $result->errors),
+                $result->exitCode
+            );
+        }
+
+        return true;
+	}
+
+	/**
+	 * Create a new validator instance using a temporary file.
+	 *
+     * @param string $contents The file contents.
+     *
+	 * @return self
+	 */
+	public static function createFromString($contents)
+	{
+		$fh = tmpfile();
+        fwrite($fh, $contents);
+
+		return new static($fh);
+	}
+
+    /**
+     * Call the underlying validate-htaccess script.
+     *
+     * @throws \RuntimeException if unable run the script.
+     *
+     * @return object {
+     *    Details about the validation run.
+     *
+     *    @type int    $exitCode The script's exit code.
+     *    @type string $errors   The contents of STDERR.
+     * }
+     *
+     * @todo Support non-standard vendor directory locations.
+     */
+    protected function runValidator()
+    {
+        $script = dirname(__DIR__) . '/vendor/bin/validate-htaccess';
+
+        if (! file_exists($script)) {
+            throw new \RuntimeException(
+                sprintf('Cannot find validation script at %s, have you installed Composer dependencies?', $script),
+                E_COMPILE_ERROR
+            );
+        }
+
+        if (! is_executable($script)) {
+            throw new \RuntimeException(
+                sprintf(
+                    'The permissions on %s do not permit it to be run by the current user (%s)',
+                    $script,
+                    posix_getpwuid(posix_geteuid())['name']
+                ),
+                E_ERROR
+            );
+        }
+
+        // Assemble and call the script.
+        $cmd  = sprintf('%1$s %2$s', escapeshellarg($script), escapeshellarg($this->getFilePath()));
+        $spec = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        $process = proc_open(escapeshellcmd($cmd), $spec, $pipes);
+
+        if (! is_resource($process)) {
+            throw new ValidationException('Unable to run validation script.');
+        }
+
+        $exitCode = proc_close($process);
+
+        return (object) [
+            'exitCode' => $exitCode,
+            'errors'   => $pipes[2],
+        ];
+    }
+}

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -146,11 +146,12 @@ class Validator
             throw new ValidationException('Unable to run validation script.');
         }
 
+        $errors   = stream_get_contents($pipes[2]);
         $exitCode = proc_close($process);
 
         return (object) [
             'exitCode' => $exitCode,
-            'errors'   => $pipes[2],
+            'errors'   => $errors,
         ];
     }
 }

--- a/tests/Integration/ValidatorTest.php
+++ b/tests/Integration/ValidatorTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Integration;
+
+use LiquidWeb\HtaccessValidator\Exceptions\ValidationException;
+use LiquidWeb\HtaccessValidator\Validator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers LiquidWeb\HtaccessValidator\Validator
+ * @testdox Validator integration tests
+ */
+class ValidatorTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_recognize_valid_configurations()
+    {
+        $content  = <<<EOT
+<IfModule mod_rewrite>
+    Options +FollowSymLinks
+    RewriteEngine on
+    RewriteCond %{HTTP_HOST} ^www.example.com [NC]
+    RewriteRule ^(.*)$ https://example.com/$1 [R=301,L]
+</IfModule>
+EOT;
+        $this->assertTrue(Validator::createFromString($content)->validate());
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_recognize_invalid_configurations()
+    {
+        $content  = <<<EOT
+<IfModule mod_rewrite>
+    Options +FollowSymLinks!!
+    RewriteEngine 👍
+    RewriteCond %{HTTP_HOST ^www.example.com [NC]
+    RewriteRules ^(.*)$ https://example.com/$1 [R=301,L]
+EOT;
+
+        $this->expectException(ValidationException::class);
+        Validator::createFromString($content)->validate();
+    }
+}

--- a/tests/Unit/ValidatorTest.php
+++ b/tests/Unit/ValidatorTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Tests\Unit;
+
+use LiquidWeb\HtaccessValidator\Exceptions\ValidationException;
+use LiquidWeb\HtaccessValidator\Validator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers LiquidWeb\HtaccessValidator\Validator
+ * @testdox Validator class unit tests
+ */
+class ValidatorTest extends TestCase
+{
+    /**
+     * @test
+     * @testdox getFilePath() should return the system path to regular files
+     */
+    public function getFilePath_should_return_the_path_to_regular_files()
+    {
+        $this->assertSame('/path/to/some-file', (new Validator('/path/to/some-file'))->getFilePath());
+    }
+
+    /**
+     * @test
+     * @testdox getFilePath() should return the system path to temporary files
+     */
+    public function getFilePath_should_return_the_path_to_resources()
+    {
+        $fh = tmpfile();
+
+        $this->assertSame(
+            stream_get_meta_data($fh)['uri'],
+            (new Validator($fh))->getFilePath()
+        );
+    }
+
+    /**
+     * @test
+     * @testdox isValid() should return true if validation passes
+     */
+    public function isValid_should_return_true_if_validation_passes()
+    {
+        $instance = $this->getMockBuilder(Validator::class)
+            ->setConstructorArgs(['/path/to/some-file'])
+            ->setMethodsExcept(['isValid'])
+            ->getMock();
+        $instance->expects($this->once())
+            ->method('validate')
+            ->willReturn(true);
+
+        $this->assertTrue($instance->isValid());
+    }
+
+    /**
+     * @test
+     * @testdox isValid() should return false if validation fails
+     */
+    public function isValid_should_return_false_if_validation_fails()
+    {
+        $instance = $this->getMockBuilder(Validator::class)
+            ->setConstructorArgs(['/path/to/some-file'])
+            ->setMethodsExcept(['isValid'])
+            ->getMock();
+        $instance->expects($this->once())
+            ->method('validate')
+            ->will($this->throwException(new ValidationException('Something went wrong')));
+
+        $this->assertFalse($instance->isValid());
+    }
+
+    /**
+     * @test
+     * @testdox validate() should return true if validation passes
+     */
+    public function validate_should_return_true_if_validation_passes()
+    {
+        $instance = $this->getMockBuilder(Validator::class)
+            ->setConstructorArgs(['/path/to/some-file'])
+            ->setMethods(['runValidator'])
+            ->getMock();
+        $instance->expects($this->once())
+            ->method('runValidator')
+            ->willReturn((object) [
+                'exitCode' => 0,
+            ]);
+
+        $instance->validate();
+    }
+
+    /**
+     * @test
+     * @testdox validate() should throw a ValidationException if the script encounters an error
+     */
+    public function validate_should_throw_a_ValidationException_if_the_validator_encountered_an_error()
+    {
+        $instance = $this->getMockBuilder(Validator::class)
+            ->setConstructorArgs(['/path/to/some-file'])
+            ->setMethods(['runValidator'])
+            ->getMock();
+        $instance->method('runValidator')
+            ->will($this->throwException(new \RuntimeException('Shell script is missing')));
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Shell script is missing');
+
+        $instance->validate();
+    }
+
+    /**
+     * @test
+     * @testdox validate() should throw a ValidationException if validation fails
+     */
+    public function validate_should_throw_an_exception_if_validation_fails()
+    {
+        $instance = $this->getMockBuilder(Validator::class)
+            ->setConstructorArgs(['/path/to/some-file'])
+            ->setMethods(['runValidator'])
+            ->getMock();
+        $instance->method('runValidator')
+            ->willReturn((object) [
+                'exitCode' => 2,
+                'errors'   => 'Some error describing some issue',
+            ]);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Some error describing some issue');
+
+        $instance->validate();
+    }
+
+    /**
+     * @test
+     * @testdox createFromString() should create a temp file with the given content
+     */
+    public function createFromString_should_create_a_temp_file_with_the_given_content()
+    {
+        $contents = <<<EOT
+Options +FollowSymLinks
+RewriteEngine on
+RewriteCond %{HTTP_HOST} ^www.example.com [NC]
+RewriteRule ^(.*)$ https://example.com/$1 [R=301,L]
+EOT;
+
+        $validator = Validator::createFromString($contents);
+        $tmpfile   = $validator->getFilePath();
+
+        $this->assertTrue(file_exists($tmpfile));
+        $this->assertSame($contents, file_get_contents($tmpfile));
+    }
+}


### PR DESCRIPTION
This PR pulls over the `Validator` class from the liquidweb/htaccess-validator repository to create a new Composer package that includes the now-standalone validate-htaccess script.

This is the companion PR to (and is blocked by) liquidweb/htaccess-validator#6, and includes code from @peter279k (see liquidweb/htaccess-validator#3).