### PR TITLE
Introduce PHP_CodeSniffer for coding standards checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,5 +16,9 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
+[*.yml]
+indent_style = space
+indent_size = 2
+
 [*.md]
 indent_style = tab

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,3 +41,34 @@ jobs:
 
       - name: Run test suite
         run: composer test:unit
+
+  coding-standards:
+    name: Coding standards
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          coverage: none
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-suggest --no-progress
+
+      - name: Run test suite
+        run: composer test:standards

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<ruleset name="liquidweb/htaccess-validator-php">
+    <description>Coding standards for liquidweb/htaccess-validator-php.</description>
+
+    <!-- What to scan -->
+    <file>./src</file>
+    <file>./tests</file>
+
+    <!-- How to scan -->
+    <!-- Usage instructions: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
+    <!-- Annotated ruleset: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+    <arg value="sp" />
+    <arg name="basepath" value="./" />
+    <arg name="colors" />
+    <arg name="extensions" value="php" />
+    <arg name="parallel" value="8" />
+
+    <!-- Use PSR-12 as the base. -->
+    <rule ref="PSR12" />
+
+    <!-- Rules: PHPCompatibilityWP -->
+    <!-- https://github.com/PHPCompatibility/PHPCompatibilityWP -->
+    <config name="testVersion" value="5.6-" />
+    <rule ref="PHPCompatibility" />
+
+    <!-- Tests may use snake_case for method names. -->
+    <rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
+        <exclude-pattern>./tests</exclude-pattern>
+    </rule>
+</ruleset>

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,8 @@
         "liquidweb/htaccess-validator-shell": "dev-develop"
     },
     "require-dev": {
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
+        "phpcompatibility/php-compatibility": "^9.3",
         "symfony/phpunit-bridge": "^5.2"
     },
     "autoload": {
@@ -36,9 +38,17 @@
         "sort-packages": true
     },
     "scripts": {
+        "test": "@test:all",
+        "test:all": [
+            "@test:unit",
+            "@test:standards"
+        ],
+        "test:standards": "phpcs",
         "test:unit": "simple-phpunit --testdox --color=always"
     },
     "scripts-descriptions": {
+        "test:all": "Run all automated tests.",
+        "test:standards": "Check coding standards.",
         "test:unit": "Run the PHPUnit test suite."
     }
 }

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -6,61 +6,61 @@ use LiquidWeb\HtaccessValidator\Exceptions\ValidationException;
 
 class Validator
 {
-	/**
-	 * @var string|Resource The file being validated.
-	 */
-	protected $file;
+    /**
+     * @var string|Resource The file being validated.
+     */
+    protected $file;
 
-	/**
-	 * Construct a new instance of the class.
-	 *
-	 * @param string|resource $file The file being validated. This may be an actual file or a
+    /**
+     * Construct a new instance of the class.
+     *
+     * @param string|resource $file The file being validated. This may be an actual file or a
      *                              stream resource.
-	 */
-	public function __construct($file)
-	{
-		$this->file = $file;
-	}
+     */
+    public function __construct($file)
+    {
+        $this->file = $file;
+    }
 
-	/**
-	 * Retrieve the underlying filepath.
-	 *
-	 * @return string The path to $this->file.
-	 */
-	public function getFilePath()
-	{
-		return is_resource($this->file)
+    /**
+     * Retrieve the underlying filepath.
+     *
+     * @return string The path to $this->file.
+     */
+    public function getFilePath()
+    {
+        return is_resource($this->file)
             ? stream_get_meta_data($this->file)['uri']
             : (string) $this->file;
-	}
+    }
 
-	/**
-	 * Simply return whether or not the given file's syntax is valid.
-	 *
-	 * @return bool True if validation passes, false if an error is encountered.
-	 */
-	public function isValid()
-	{
-		try {
-			$this->validate();
-		} catch (ValidationException $e) {
-			return false;
-		}
+    /**
+     * Simply return whether or not the given file's syntax is valid.
+     *
+     * @return bool True if validation passes, false if an error is encountered.
+     */
+    public function isValid()
+    {
+        try {
+            $this->validate();
+        } catch (ValidationException $e) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	/**
-	 * Validate the given file.
-	 *
-	 * Validation is handled by the underlying Apache instance, using a stripped-down configuration
-	 * so the entire Apache configuration consists of a) the necessary bootstrapping and b) the
-	 * contents of $this->file.
-	 *
-	 * @throws ValidationException
-	 */
-	public function validate()
-	{
+    /**
+     * Validate the given file.
+     *
+     * Validation is handled by the underlying Apache instance, using a stripped-down configuration
+     * so the entire Apache configuration consists of a) the necessary bootstrapping and b) the
+     * contents of $this->file.
+     *
+     * @throws ValidationException
+     */
+    public function validate()
+    {
         try {
             $result = $this->runValidator();
         } catch (\Exception $e) {
@@ -71,7 +71,7 @@ class Validator
             );
         }
 
-		if (0 !== $result->exitCode) {
+        if (0 !== $result->exitCode) {
             throw new ValidationException(
                 sprintf('Validation errors were encountered: %s', $result->errors),
                 $result->exitCode
@@ -79,22 +79,22 @@ class Validator
         }
 
         return true;
-	}
+    }
 
-	/**
-	 * Create a new validator instance using a temporary file.
-	 *
+    /**
+     * Create a new validator instance using a temporary file.
+     *
      * @param string $contents The file contents.
      *
-	 * @return self
-	 */
-	public static function createFromString($contents)
-	{
-		$fh = tmpfile();
+     * @return self
+     */
+    public static function createFromString($contents)
+    {
+        $fh = tmpfile();
         fwrite($fh, $contents);
 
-		return new static($fh);
-	}
+        return new static($fh);
+    }
 
     /**
      * Call the underlying validate-htaccess script.


### PR DESCRIPTION
This PR adds [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) along with [the PHPCompatibility ruleset](https://github.com/PHPCompatibility/PHPCompatibility) for checking coding standards as part of the CI pipeline.

Blocked by #3.