### PR TITLE
Check multiple paths for the shell script

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,15 @@ There are two ways to instantiate the class:
 1. Passing the full system path of the file under validation to the class constructor:
 
 	```php
-    use LiquidWeb\HtaccessValidator\Validator;
+	use LiquidWeb\HtaccessValidator\Validator;
 
 	$validator = new Validator($file);
 	```
 
 2. Passing the configuration directly to the `::createFromString()` factory method:
 
-    ```php
-    use LiquidWeb\HtaccessValidator\Validator;
+	```php
+	use LiquidWeb\HtaccessValidator\Validator;
 
 	$validator = Validator::createFromString('Options +FollowSymLinks');
 	```
@@ -61,4 +61,18 @@ $validator->validate();
 
 # Return a boolean.
 $validator->isValid();
+```
+
+#### Modifying the path to the validator shell script
+
+By default, the library assumes that the `validate-htaccess` shell script lives in `vendor/bin/`.
+
+If you're using a non-standard Composer configuration, you can explicitly specify the path by setting the `HTACCESS_VALIDATOR_SCRIPT` environment variable, either in your environment configuration or inline:
+
+```php
+# Absolute system path to the shell script.
+putenv('HTACCESS_VALIDATOR_SCRIPT=/some/path/to/vendor/bin/htaccess-validator');
+
+# Will now use the Htaccess Validator script specified above.
+$validator = (new Validator($file))->validate();
 ```

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -107,14 +107,25 @@ class Validator
      *    @type int    $exitCode The script's exit code.
      *    @type string $errors   The contents of STDERR.
      * }
-     *
-     * @todo Support non-standard vendor directory locations.
      */
     protected function runValidator()
     {
-        $script = dirname(__DIR__) . '/vendor/bin/validate-htaccess';
+        // Locate the validate-htaccess shell script.
+        $script = '';
+        $paths  = [
+            getenv('HTACCESS_VALIDATOR_SCRIPT'),
+            dirname(__DIR__) . '/vendor/bin/validate-htaccess',
+            dirname(dirname(dirname(__DIR__))) . '/bin/validate-htaccess',
+        ];
 
-        if (! file_exists($script)) {
+        foreach ($paths as $path) {
+            if ($path && file_exists($path)) {
+                $script = $path;
+                break;
+            }
+        }
+
+        if (! $script) {
             throw new \RuntimeException(
                 sprintf('Cannot find validation script at %s, have you installed Composer dependencies?', $script),
                 E_COMPILE_ERROR


### PR DESCRIPTION
Depending on how the library is installed, the shell script may be in different locations relative to the Validator.php class definition:

1. When this is the root package: `../vendor/bin/validate-htaccess`
2. When this is installed in another package: `../../../bin/validate-htaccess`

Additionally, non-standard Composer configurations could have the vendor dir in a completely different place. To support this, the path can be explicitly passed via the `HTACCESS_VALIDATOR_SCRIPT` environment variable.